### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ vagrant ssh node1
 node1 $ /vagrant/declare-shovel.sh
 ```
 
-Management plugin is available on http://192.168.33.11:15672 and http://192.168.33.12:15672 (user / password is admin / admin).
+Management plugin is available on https://192.168.33.11:15672 and https://192.168.33.12:15672 (user / password is admin / admin).
 
 ## Sending messages
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://192.168.33.11:15672 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.33.11:15672 ([https](https://192.168.33.11:15672) result ConnectTimeoutException).
* http://192.168.33.12:15672 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.33.12:15672 ([https](https://192.168.33.12:15672) result ConnectTimeoutException).